### PR TITLE
Fixed gas used treated as hex but is decimal.

### DIFF
--- a/src/pages/TransactionPage/index.tsx
+++ b/src/pages/TransactionPage/index.tsx
@@ -82,7 +82,7 @@ export const TransactionPage = () => {
       if (trx) {
         const txnReceipt = await hmyv2_getTransactionReceipt([id], shard);
         if (txnReceipt && txnReceipt.result && txnReceipt.result.gasUsed) {
-          trx.gas = parseInt(txnReceipt.result.gasUsed, 16).toString();
+          trx.gas = parseInt(txnReceipt.result.gasUsed).toString();
         }
       }
       


### PR DESCRIPTION
@murryarc pointed out on telegram that the values of gasUsed from hmyv2_getTransactionReceipt and hmy_getTransactionReceipt differ.

after some investigation it seems that;
hmyv2_getTransactionReceipt returns gasUsed as decimal
hmy_getTransactionReceipt returns gasUsed as hexadecimal

The explorer transformed the decimal one with the hex base, leading to an error in the gasUsed and the resulting transactionFee calculated.

I created an example here:
[0x5733742fdea3cd698f2c297717cf5ca60aac7753bf29226b11180ff28e9f91ac](https://explorer.harmony.one/tx/0x221e8d7f7e1756a936d737ce09f3425c739d7729e6cef5d225f2c3463529d488)

1. A new wallet got funded with 1 one
2. Sending 0.9 one back to the funding wallet
3. TX cost shown in current version: 0.00270336
4. remaining funds in wallet: 0.099580
5. Actual cost: 0.1 - 0.099580 = 0.0004200000000000037

This PR fixes this issue.