### PR TITLE
fix: gasUsed shown does not match hmy_v2_transactionReceipt (#97)

### DIFF
--- a/src/pages/TransactionPage/index.tsx
+++ b/src/pages/TransactionPage/index.tsx
@@ -82,7 +82,8 @@ export const TransactionPage = () => {
       if (trx) {
         const txnReceipt = await hmyv2_getTransactionReceipt([id], shard);
         if (txnReceipt && txnReceipt.result && txnReceipt.result.gasUsed) {
-          trx.gas = parseInt(txnReceipt.result.gasUsed, 16).toString();
+          trx.gas = txnReceipt.result.gasUsed; 
+          //#97 - hmy_v2 returns number, not hexparseInt(txnReceipt.result.gasUsed, 16).toString();
         }
       }
       


### PR DESCRIPTION
This patch is a fix for https://github.com/harmony-one/explorer-v2-frontend/issues/97

The issue is that hmy_getTransactionReceipt returns a hexadecimal and needed to be decoded to decimal while hmy_v2_getTransactionReceipt does not. The code used the incorrect version of getTransactionReceipt endpoint to decode gasUsed and hence showed the value 135168 instead of (the correct value) 21000.