### PR TITLE
Fix blank page on loading ERC tokens; use indexedDB instead of LS

### DIFF
--- a/src/components/ERC1155_Pool.tsx
+++ b/src/components/ERC1155_Pool.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react";
 import { getAllERC1155 } from "src/api/client";
 import { setERC1155Pool, ERC1155 } from "src/hooks/ERC1155_Pool";
+import { IndexedDbKeyPath, IndexedDbStore, saveToIndexedDB } from "../utils/indexedDB";
 
 export function ERC1155_Pool() {
   useEffect(() => {
@@ -8,14 +9,21 @@ export function ERC1155_Pool() {
 
     const getRates = async () => {
       try {
-        const erc1155: ERC1155[] = await getAllERC1155();
         const erc1155Map = {} as Record<string, ERC1155>;
-        erc1155.forEach((i: any) => {
-          erc1155Map[i.address] = i;
-        });
-
-        window.localStorage.setItem("ERC1155_Pool", JSON.stringify(erc1155Map));
+        let erc1155: ERC1155[] = await getAllERC1155();
+        erc1155 = erc1155.map(item => {
+          erc1155Map[item.address] = item;
+          return {
+            [IndexedDbKeyPath]: item.address,
+            ...item
+          }
+        })
         setERC1155Pool(erc1155Map);
+        await saveToIndexedDB(IndexedDbStore.ERC1155Pool, erc1155)
+        localStorage.setItem(IndexedDbStore.ERC1155Pool, '1')
+        console.log(`ERC1155 tokens is updated, count: ${erc1155.length}`)
+      } catch (e) {
+        console.error('Cannot update ERC1155 tokens', (e as Error).message)
       } finally {
         clearTimeout(tId);
         tId = window.setTimeout(getRates, 10 * 60 * 1e3);
@@ -26,7 +34,7 @@ export function ERC1155_Pool() {
       () => {
         getRates();
       },
-      window.localStorage.getItem("ERC1155_Pool") ? 2200 : 0
+      window.localStorage.getItem(IndexedDbStore.ERC1155Pool) ? 2200 : 0
     );
 
     return () => {

--- a/src/hooks/ERC20_Pool.ts
+++ b/src/hooks/ERC20_Pool.ts
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { singletonHook } from "react-singleton-hook";
+import { IndexedDbStore, loadFromIndexedDB } from "../utils/indexedDB";
 
 const initValue: ERC20_Pool = {};
 
@@ -8,12 +9,24 @@ let globalSetMode = () => {
 };
 
 export const useERC20Pool = singletonHook(initValue, () => {
-  const pool =
-    (JSON.parse(
-      window.localStorage.getItem("ERC20_Pool") || "{}"
-    ) as ERC20_Pool) || initValue;
+  const getPool = async () => {
+    try {
+      const erc20 = await loadFromIndexedDB(IndexedDbStore.ERC20Pool)
+      const erc20Map = {} as Record<string, Erc20>;
+      erc20.forEach(item => {
+        erc20Map[item.address] = item;
+      })
+      setMode(erc20Map)
+    } catch (e) {
+      console.error('Cannot get ERC20 records: ', (e as Error).message)
+    }
+  }
 
-  const [mode, setMode] = useState<ERC20_Pool>(pool);
+  useEffect(() => {
+    getPool()
+  }, [])
+
+  const [mode, setMode] = useState<ERC20_Pool>(initValue);
   //@ts-ignore
   globalSetMode = setMode;
   return mode;

--- a/src/pages/AddressPage/TokenInfo.tsx
+++ b/src/pages/AddressPage/TokenInfo.tsx
@@ -45,7 +45,7 @@ export function TokensInfo(props: { value: Token[] }) {
 
   const erc20Tokens = value
     .filter((i) => filterWithBalance(i.balance))
-    .filter((i) => i.isERC20)
+    .filter((i) => i.isERC20 && erc20Map[i.tokenAddress])
     .map((item) => ({
       ...item,
       symbol: erc20Map[item.tokenAddress].symbol,
@@ -55,7 +55,7 @@ export function TokensInfo(props: { value: Token[] }) {
 
   const erc721Tokens = value
     .filter((i) => filterWithBalance(i.balance))
-    .filter((i) => i.isERC721)
+    .filter((i) => i.isERC721 && erc721Map[i.tokenAddress])
     .map((item) => ({
       ...item,
       symbol: erc721Map[item.tokenAddress].symbol,
@@ -64,7 +64,7 @@ export function TokensInfo(props: { value: Token[] }) {
 
   const erc1155Tokens = value
     .filter((i) => filterWithBalance(i.balance))
-    .filter((i) => i.isERC1155)
+    .filter((i) => i.isERC1155 && erc1155Map[i.tokenAddress])
     .map((item) => ({
       ...item,
       symbol: erc1155Map[item.tokenAddress].symbol,

--- a/src/pages/ERC20List/ERC20Table.tsx
+++ b/src/pages/ERC20List/ERC20Table.tsx
@@ -152,7 +152,7 @@ function getColumns(props: any) {
       render: (data: Erc20) => <Address address={data.address} displayHash />,
     },
     {
-      property: "totalSupply",
+      property: "circulatingSupply",
       size: "small",
       resizeable: false,
       header: (

--- a/src/utils/indexedDB.ts
+++ b/src/utils/indexedDB.ts
@@ -1,0 +1,84 @@
+export enum IndexedDbStore {
+  ERC1155Pool = 'ERC1155_Pool',
+  ERC20Pool = 'ERC20_Pool',
+  ERC721Pool = 'ERC721_Pool',
+}
+
+export const IndexedDbKeyPath = '_id'
+
+const DbVersion = 1
+
+export const saveToIndexedDB = (storeName: IndexedDbStore, objects: any[]) => {
+  return new Promise(
+    function(resolve, reject) {
+      const dbRequest = indexedDB.open(storeName, DbVersion);
+
+      dbRequest.onerror = function() {
+        reject(Error('IndexedDB error'));
+      };
+
+      dbRequest.onupgradeneeded = function(event) {
+        // @ts-ignore
+        const db = event.target.result;
+        db.createObjectStore(storeName, { keyPath: IndexedDbKeyPath });
+      };
+
+      dbRequest.onsuccess = function() {
+        let db = dbRequest.result;
+        db.onversionchange = function() {
+          db.close();
+          console.log('Database is outdated, please reload the page');
+        };
+        const transaction = db.transaction([storeName], 'readwrite');
+        const objectStore = transaction.objectStore(storeName);
+        objects.forEach((item, i, arr) => {
+          const objectRequest = objectStore.put(item);
+          if (i === arr.length - 1) {
+            objectRequest.onsuccess = function() {
+              resolve('Data saved');
+            };
+          }
+        })
+      };
+
+      dbRequest.onblocked = function() {
+        reject(Error(`IndexedDB ${storeName} is blocked`));
+      };
+    }
+  );
+}
+
+export const loadFromIndexedDB = (storeName: IndexedDbStore): Promise<any[]> => {
+  return new Promise(
+    function(resolve, reject) {
+      const dbRequest = indexedDB.open(storeName, DbVersion);
+
+      dbRequest.onerror = function() {
+        reject(Error('IndexedDB error'));
+      };
+
+      dbRequest.onupgradeneeded = function(event) {
+        // @ts-ignore
+        event.target.transaction.abort();
+        reject(Error('Not found'));
+      };
+
+      dbRequest.onsuccess = function(event) {
+        // @ts-ignore
+        const database = event.target.result;
+        const transaction = database.transaction([storeName]);
+        const objectStore = transaction.objectStore(storeName);
+        const objectRequest = objectStore.getAll();
+
+        objectRequest.onerror = function(e: Error) {
+          reject(Error(`Indexed db error: ${e.message}`));
+        };
+
+        objectRequest.onsuccess = function(event: any) {
+          if (objectRequest.result) resolve(objectRequest.result);
+          else reject(Error('Objects is not found'));
+        };
+      };
+    }
+  );
+}


### PR DESCRIPTION
LocalStorage have a 10Mb limit per origin. ERC tokens list exceeded the limit.

This improvement provides:
1. indexedDb instead of localStorage with much more storage limit;
2. fix case if tokens is not loaded yet and address tokens component is rendered.