### PR TITLE
update: added tab focus support #118, fixed chart display #137

### DIFF
--- a/src/components/ERC1155_Pool.tsx
+++ b/src/components/ERC1155_Pool.tsx
@@ -1,14 +1,20 @@
 import React, { useEffect } from "react";
 import { getAllERC1155 } from "src/api/client";
 import { setERC1155Pool, ERC1155 } from "src/hooks/ERC1155_Pool";
+import { getTabHidden, useWindowFocused } from "src/hooks/useWindowFocusHook";
 import { IndexedDbKeyPath, IndexedDbStore, saveToIndexedDB } from "../utils/indexedDB";
 import { isTokenBridged } from "../utils";
 
 export function ERC1155_Pool() {
+  const focus = useWindowFocused();
+
   useEffect(() => {
     let tId = 0;
 
     const getRates = async () => {
+      if (getTabHidden()) {
+        return; // ignore when tab is hidden
+      }
       try {
         const erc1155Map = {} as Record<string, ERC1155>;
         let erc1155: ERC1155[] = await getAllERC1155();

--- a/src/components/ERC20_Pool.tsx
+++ b/src/components/ERC20_Pool.tsx
@@ -1,14 +1,19 @@
 import React, { useEffect } from "react";
 import { getAllERC20 } from "src/api/client";
 import { setERC20Pool, Erc20 } from "src/hooks/ERC20_Pool";
+import { getTabHidden, useWindowFocused } from "src/hooks/useWindowFocusHook";
 import { IndexedDbKeyPath, IndexedDbStore, saveToIndexedDB } from "../utils/indexedDB";
 import { isTokenBridged } from "../utils";
 
 export function ERC20_Pool() {
+  const focus = useWindowFocused();
   useEffect(() => {
     let tId = 0;
 
     const getRates = async () => {
+      if (getTabHidden()) {
+        return; // hidden tab, ignore the refresh request
+      }
       try {
         let erc20: Erc20[] = await getAllERC20();
         const erc20Map = {} as Record<string, Erc20>;

--- a/src/components/ERC721_Pool.tsx
+++ b/src/components/ERC721_Pool.tsx
@@ -1,15 +1,21 @@
 import React, { useEffect } from "react";
 import { getAllERC721 } from "src/api/client";
 import { setERC721Pool, ERC721 } from "src/hooks/ERC721_Pool";
+import { getTabHidden, useWindowFocused } from "src/hooks/useWindowFocusHook";
 import { IndexedDbKeyPath, IndexedDbStore, saveToIndexedDB } from "../utils/indexedDB";
 import { isTokenBridged } from "../utils";
 
 export function ERC721_Pool() {
+  const focus = useWindowFocused();
+
   useEffect(() => {
     let tId = 0;
 
     const getRates = async () => {
       try {
+        if (getTabHidden()) {
+          return; // tab is hidden don't refresh
+        }
         let erc721: ERC721[] = await getAllERC721();
         const erc721Map = {} as Record<string, ERC721>;
         erc721 = erc721.map((item) => {

--- a/src/components/block/BlockDetails.tsx
+++ b/src/components/block/BlockDetails.tsx
@@ -10,6 +10,7 @@ import { TipContent } from "src/components/ui";
 import { Box, DataTable, Tip, Anchor, Text } from "grommet";
 
 import { CircleQuestion, CaretDownFill, CaretUpFill } from "grommet-icons";
+import { useWindowFocused } from "src/hooks/useWindowFocusHook";
 
 const columns = [
   {
@@ -52,6 +53,8 @@ export const BlockDetails: FunctionComponent<BlockDetailsProps> = ({
 }) => {
   const [showDetails, setShowDetails] = useState(true);
   const [isNewAddress, setIsNewAddress] = useState<boolean>(false);
+  const focus = useWindowFocused();
+  console.log(focus, "block details");
 
   useEffect(() => {
     let tId = 0;

--- a/src/components/metrics/index.tsx
+++ b/src/components/metrics/index.tsx
@@ -58,6 +58,15 @@ export const options = {
       grid: {
         display: false,
         drawBorder: false,
+      },
+      ticks: {
+        // For a category axis, the val is the index so the lookup via getLabelForValue is needed
+        // @ts-ignore
+        callback: function(val:any, index:any) {
+          // @ts-ignore
+          if (val === 0) return "";
+          return val;
+        },
       }
     }
   }
@@ -342,11 +351,22 @@ function BlockTransactionsHistory() {
   const data = {
     labels: result.map((i) => dayjs(i.timestamp).format("DD-MM")),
     datasets: [{
-      label: "Wallets",
+      label: "Transactions",
       data: result.map((i) => +i.count),
       backgroundColor: 'rgba(0, 174, 233, 0.5)'
     }]
   }
+
+  let max = 0;
+  result.forEach(e=>{
+    if (max < +e.count) {
+      max = +e.count;
+    }
+  });
+
+  const opts = {...options};
+  // @ts-ignore
+  opts.scales.y.ticks.stepSize = Math.round(max/4);
 
   return (
     <Box>
@@ -360,7 +380,7 @@ function BlockTransactionsHistory() {
           </Box>
         )}
         {!isLoading && (
-          <Bar options={options} data={data} height="110px" />
+          <Bar options={opts} data={data} height="110px" />
         )}
       </Box>
     </Box>
@@ -402,6 +422,17 @@ function WalletsHistory() {
     }]
   }
 
+  let max = 0;
+  result.forEach(e=>{
+    if (max < +e.count) {
+      max = +e.count;
+    }
+  });
+
+  const opts = {...options};
+  // @ts-ignore
+  opts.scales.y.ticks.stepSize = Math.round(max/4);
+  
   return (
     <Box>
       <Text size="small" color="minorText" style={{ flex: "1 0 auto" }}>
@@ -414,7 +445,7 @@ function WalletsHistory() {
           </Box>
         )}
         {!isLoading && (
-          <Bar options={options} data={data} height="110px" />
+          <Bar options={opts} data={data} height="110px" />
         )}
       </Box>
     </Box>

--- a/src/hooks/polling.tsx
+++ b/src/hooks/polling.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, Dispatch } from 'react'
+import { getTabHidden, useWindowFocused } from './useWindowFocusHook';
 
 export type APIPollingOptions<DataType> = {
   fetchFunc: () => Promise<DataType>
@@ -10,6 +11,7 @@ export type APIPollingOptions<DataType> = {
 
 function useAPIPolling<DataType>(opts: APIPollingOptions<DataType>): DataType {
   const { initialState, fetchFunc, delay, onError, updateTrigger } = opts
+  const focus = useWindowFocused();
 
   const timerId = useRef<any>()
   const fetchCallId = useRef(0)
@@ -37,6 +39,9 @@ function useAPIPolling<DataType>(opts: APIPollingOptions<DataType>): DataType {
   }
 
   const pollingRoutine = () => {
+    if (getTabHidden()) {
+      return; // don't poll if the tab is hidden
+    }
     fetchCallId.current += 1
     /* tslint:disable no-floating-promises */
     fetchData(fetchCallId.current).then(() => {

--- a/src/hooks/useWindowFocusHook.ts
+++ b/src/hooks/useWindowFocusHook.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { singletonHook } from "react-singleton-hook";
+
+const currentFocus: focusType = true;
+
+let globalGetHidden = () => {
+    throw new Error("you must useWindowFocus before setting its state");
+};
+
+export const useWindowFocused = singletonHook(currentFocus, () => {
+    const currentFocus = document.hidden;
+
+    const [hidden, setHidden] = useState<focusType>(currentFocus);
+
+    useEffect(() => {
+        const tabListener = function () {
+            setHidden(document.hidden);
+        };
+        window.addEventListener("visibilitychange", tabListener);
+
+        return () => {
+            window.removeEventListener("visibilitychange", tabListener);
+        }
+    }, [])
+    //@ts-ignore
+    globalGetHidden = () => {
+        return hidden;
+    };
+    return hidden;
+});
+
+export type focusType = true | false;
+export const getTabHidden = () => {
+    return globalGetHidden();
+}
+// export const getStoredValue = () => window.localStorage.getItem('currency') as currencyType || initCurrency

--- a/src/pages/AddressPage/index.tsx
+++ b/src/pages/AddressPage/index.tsx
@@ -117,8 +117,8 @@ export function AddressPage() {
   let type = erc721Map[id]
     ? "erc721"
     : erc1155Map[id]
-    ? "erc1155"
-    : getType(contracts, erc20Token);
+      ? "erc1155"
+      : getType(contracts, erc20Token);
 
   try {
     oneAddress = getAddress(oneAddress).bech32;
@@ -180,13 +180,13 @@ export function AddressPage() {
             type === "erc721"
               ? await getTokenERC721Assets([id])
               : await (
-                  await getTokenERC1155Assets([id])
-                ).map((item) => {
-                  if (item.meta && item.meta.image) {
-                    item.meta.image = `${process.env.REACT_APP_INDEXER_IPFS_GATEWAY}${item.meta.image}`;
-                  }
-                  return item;
-                });
+                await getTokenERC1155Assets([id])
+              ).map((item) => {
+                if (item.meta && item.meta.image) {
+                  item.meta.image = `${process.env.REACT_APP_INDEXER_IPFS_GATEWAY}${item.meta.image}`;
+                }
+                return item;
+              });
 
           let inventoryHolders1155 = [] as any[];
 
@@ -382,9 +382,21 @@ export function AddressPage() {
 
           {type === "erc20" &&
             <Tab title={<Text size="small">Events</Text>}>
-              <EventsTab id={id}/>
+              <EventsTab id={id} />
             </Tab>
           }
+
+          {type === "erc721" || type === "erc1155" || type === "erc20" ? (
+            <Tab title={<Text size="small">Tools</Text>}>
+              <HoldersTab
+                id={id}
+                type={type}
+                inventory={
+                  inventoryHolders.length ? inventoryHolders : inventory
+                }
+              />
+            </Tab>
+          ) : null}
 
           {/*{type === "erc1155" && inventory.length ? (*/}
           {/*  <Tab*/}

--- a/src/pages/MainPage/LatestTransactionsTable.tsx
+++ b/src/pages/MainPage/LatestTransactionsTable.tsx
@@ -7,6 +7,7 @@ import { Address } from "src/components/ui";
 import { getTransactions } from "src/api/client";
 import { FormNextLink } from "grommet-icons";
 import { DateTime } from "../../components/ui";
+import { getTabHidden, useWindowFocused } from "src/hooks/useWindowFocusHook";
 
 function getColumns(props: any) {
   const { history } = props;
@@ -97,6 +98,8 @@ const filter = {
 };
 
 export function LatestTransactionsTable() {
+  const hidden = useWindowFocused();
+
   const history = useHistory();
   const [transactions, setTransactions] = useState<RPCTransactionHarmony[]>([]);
   const availableShards = (process.env.REACT_APP_AVAILABLE_SHARDS as string)
@@ -107,6 +110,11 @@ export function LatestTransactionsTable() {
     let tId = 0 as any;
     const exec = async () => {
       try {
+        const hidden = getTabHidden();
+        if (hidden) {
+          // tab is not focused 
+          return;
+        }
         let trxs = await Promise.all(
           availableShards.map((shardNumber) =>
             getTransactions([shardNumber, filter])

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -12,6 +12,7 @@ import { Block } from "src/types";
 import { getBlocks } from "src/api/client";
 import { calculateSecondPerBlocks, calculateSecondsPerBlock } from "./helpers";
 import { ShardDropdown } from "src/components/ui/ShardDropdown";
+import { getTabHidden, useWindowFocused } from "src/hooks/useWindowFocusHook";
 
 const filter = {
   offset: 0,
@@ -23,6 +24,8 @@ const filter = {
 };
 
 export function MainPage() {
+  const focus = useWindowFocused();
+
   const history = useHistory();
   const isLessDesktop = useMediaQuery({ maxDeviceWidth: breakpoints.desktop });
 
@@ -39,6 +42,10 @@ export function MainPage() {
     let tId = 0 as any;
     const exec = async () => {
       try {
+        if (getTabHidden()) {
+          // ignore if not focused, we don't load blocks ...
+          return;
+        }; 
         let allBlocks = [];
         let blocks = await Promise.all(
           selectedShard === "All Shards"


### PR DESCRIPTION
This fix addresses two issues, 
- fixing the chart display so that it doesn't start at 0 #137. Achieved by adjusting the stepSize
- Added tab focus and disabling high-volume RPC and WSS requests when the users have a tab. Achieved by adding visibilitylistener on document

I also added a change that renamed the Wallet to Transaction in the main page charts.

