### PR TITLE
update: fixed #140 - did not enable button when abi not a view

### DIFF
--- a/src/pages/AddressPage/ContractDetails/AbiMethodView.tsx
+++ b/src/pages/AddressPage/ContractDetails/AbiMethodView.tsx
@@ -273,7 +273,7 @@ export const AbiMethodsView = (props: {
           </Box>
         ) : null}
 
-        {!result || abiMethod.inputs?.length ? (
+        {!result || abiMethod.inputs?.length || abiMethod.stateMutability !== 'view' ? (
           <Box width='100px' margin={{top: '20px', bottom: '18px'}}>
             {loading ? (
               <Spinner />


### PR DESCRIPTION
When not a view, if there are no inputs for the write function the WRITE button does not appear.

Checked that the WRITE button appears if its not a view (should always be visible in the WRITE tab)