### PR TITLE
Fixed And Improved Abi Viewer Return Params

### DIFF
--- a/src/components/ui/AbiParam.tsx
+++ b/src/components/ui/AbiParam.tsx
@@ -1,0 +1,51 @@
+import { Box, TextInput } from "grommet";
+import { palette } from "src/theme";
+import styled from "styled-components";
+
+
+interface IAbiParam {
+    name?: string;
+    readonly?: boolean;
+    type: string;
+    value: string;
+}
+
+const SmallTextInput = styled(TextInput)`
+  font-size: 14px;
+  font-weight: 400;
+
+  ::placeholder {
+    font-size: 14px;
+  }
+`;
+
+const HeaderBox = styled(Box)`
+  font-size:12px;
+`
+const NameLabel = styled.div`
+    color: ${palette.ElectricBlue};
+    margin-right: 20px;
+`
+
+
+export const AbiParam = (props: IAbiParam) => {
+    const {
+        name,
+        readonly,
+        type,
+        value,
+    } = props;
+
+    function valueInput() {
+        return <SmallTextInput value={value} readOnly={readonly} />
+    }
+
+    return <Box className="param-box" direction="column" pad="none">
+        <HeaderBox direction="row" align="center">
+            {name && <NameLabel>{name}</NameLabel>}
+            <i>{type}</i>
+        </HeaderBox>
+
+        {valueInput()}
+    </Box>
+};

--- a/src/pages/AddressPage/ContractDetails/AbiMethodView.tsx
+++ b/src/pages/AddressPage/ContractDetails/AbiMethodView.tsx
@@ -7,6 +7,7 @@ import {AbiItem} from 'web3-utils';
 import {convertInputs} from './helpers';
 import {uniqid} from 'src/pages/VerifyContract/VerifyContract';
 import detectEthereumProvider from '@metamask/detect-provider';
+import {AbiParam} from 'src/components/ui/AbiParam';
 
 const Field = styled(Box)``;
 
@@ -83,8 +84,8 @@ export const AbiMethodsView = (props: {
       const web3URL = props.isRead
         ? process.env.REACT_APP_RPC_URL_SHARD0
         : web3
-        ? web3
-        : process.env.REACT_APP_RPC_URL_SHARD0;
+          ? web3
+          : process.env.REACT_APP_RPC_URL_SHARD0;
 
       const hmyWeb3 = new Web3(web3URL);
 
@@ -102,7 +103,7 @@ export const AbiMethodsView = (props: {
           const accounts = await ethereum.enable();
 
           const account = accounts[0] || undefined; // if function is not a view method it will require a signer
-          
+
           console.log("account is", account);
 
           res = await contract.methods[abiMethod.name]
@@ -119,8 +120,8 @@ export const AbiMethodsView = (props: {
           Array.isArray(res)
             ? res
             : typeof res === 'object'
-            ? Object.values(res)
-            : [res.toString()]
+              ? Object.values(res)
+              : [res.toString()]
         );
       }
     } catch (e) {
@@ -147,7 +148,7 @@ export const AbiMethodsView = (props: {
   };
 
   return (
-    <ViewWrapper direction='column' margin={{bottom: 'medium'}}>
+    <ViewWrapper className='abi-view-wrapper' direction='column' margin={{bottom: 'medium'}}>
       <NameWrapper background={'backgroundBack'}>
         <Text size='small'>
           {index + 1}. {abiMethod.name}
@@ -293,30 +294,14 @@ export const AbiMethodsView = (props: {
         ) : null}
 
         {abiMethod.outputs
-          ? abiMethod.outputs.map((input) => {
-              return (
-                <Box>
-                  {result.length ? (
-                    <Text size='small'>
-                      <GreySpan>
-                        {input.name}
-                        {` (${input.type})`}
-                      </GreySpan>{' '}
-                      {'-> '}
-                      {result.length === 1 ? [result] : result.toString()}
-                    </Text>
-                  ) : (
-                    <Text size='small'>
-                      <GreySpan>
-                        {input.name}
-                        {` (${input.type})`}
-                      </GreySpan>{' '}
-                      {'-> '}
-                    </Text>
-                  )}
-                </Box>
-              );
-            })
+          ? abiMethod.outputs.map((input, idx) => {
+            return (<AbiParam
+              readonly={true}
+              type={input.type}
+              name={input.name}
+              value={result[idx]}
+            />)
+          })
           : null}
 
         {error && (


### PR DESCRIPTION
Currently the return parameters in the Contract Reader section are not separated, resulting in a list of items, showing the same array of values.

For example the `poolInfo` method on the [MaterBreeder of DFK](https://explorer.harmony.one/address/0xdb30643c71ac9e2122ca0341ed77d09d5f99f924?activeTab=7) looks like this:

![image](https://user-images.githubusercontent.com/7532600/166435725-9d8f488b-5212-4019-9f34-d4dfb30cc2ea.png)

This pull request splits the values accurately and displys them in a more readable fashion:
![image](https://user-images.githubusercontent.com/7532600/166435851-1c9f4d7d-0674-4aac-a701-5e83a90d7d80.png)

The style changes are quite opinionated, but I tried sticking to the current style.
